### PR TITLE
fix: add missing os import in personal-reply command

### DIFF
--- a/src/issuelab/__main__.py
+++ b/src/issuelab/__main__.py
@@ -364,6 +364,7 @@ def main():
     elif args.command == "personal-reply":
         # 个人Agent回复主仓库issue
         import json
+        import os
         import subprocess
         import yaml
 


### PR DESCRIPTION
## 问题描述

在 `personal-reply` 命令中使用了 `os.environ.get()` 但没有导入 `os` 模块，导致运行时出现 `name 'os' is not defined` 错误。

## 错误日志

```
❌ 发布失败: name 'os' is not defined
```

来源：https://github.com/gqy22/IssueLab/actions/runs/21621465448/job/62311280118

## 修复内容

在 `src/issuelab/__main__.py` 第367行的 `personal-reply` 命令中添加缺失的导入：

```python
import os  # 新增
```

## 影响范围

- 仅影响 `personal-reply` 命令
- 修复了跨仓库评论时的PAT token检查功能
- 不影响其他功能

## 测试

- [x] 本地验证语法正确
- [x] 确认 `os.environ.get()` 正常工作

修复了在fork仓库使用user agent时遇到的发布失败问题。